### PR TITLE
Update USPS API Endpoints to SSL

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+
+# Default ignored files
+/workspace.xml

--- a/address_validate.gemspec
+++ b/address_validate.gemspec
@@ -20,9 +20,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = '>= 2.0.0'
 
-  spec.add_dependency "ox", "~> 2.14.6"
+  spec.add_dependency "ox", "~> 2.14.18"
 
-  spec.add_development_dependency "bundler", "~> 1.11"
+  spec.add_development_dependency "bundler", "~> 2.2"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry"

--- a/address_validate.gemspec
+++ b/address_validate.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = '>= 2.0.0'
 
-  spec.add_dependency "ox", "~> 2.4.1"
+  spec.add_dependency "ox", "~> 2.14.6"
 
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/address_validate/api/request.rb
+++ b/lib/address_validate/api/request.rb
@@ -14,6 +14,7 @@ module AddressValidate
       def build_xml
         request_xml = build_node('AddressValidateRequest', nil,
                         { 'USERID' => AddressValidate.username })
+        request_xml << build_revision
         request_xml << build_address
         Ox.dump(request_xml)
       end
@@ -23,6 +24,10 @@ module AddressValidate
         attrs.each { |key, value| node[key] = value }
         node << text if text
         node
+      end
+
+      def build_revision
+        build_node('Revision', '1', {})
       end
 
       def build_address

--- a/lib/address_validate/configuration.rb
+++ b/lib/address_validate/configuration.rb
@@ -1,8 +1,8 @@
 module AddressValidate
   module Configuration
     API_URLS = {
-      test: 'http://production.shippingapis.com/ShippingAPITest.dll',
-      production: 'http://production.shippingapis.com/ShippingAPI.dll'
+      test: 'https://production.shippingapis.com/ShippingApiTest.dll',
+      production: 'https://production.shippingapis.com/ShippingAPI.dll'
     }
 
     attr_accessor :environment, :username, :password,

--- a/lib/address_validate/configuration.rb
+++ b/lib/address_validate/configuration.rb
@@ -1,7 +1,7 @@
 module AddressValidate
   module Configuration
     API_URLS = {
-      test: 'https://production.shippingapis.com/ShippingApiTest.dll',
+      test: 'https://production.shippingapis.com/ShippingAPITest.dll',
       production: 'https://production.shippingapis.com/ShippingAPI.dll'
     }
 

--- a/lib/address_validate/version.rb
+++ b/lib/address_validate/version.rb
@@ -1,3 +1,3 @@
 module AddressValidate
-  VERSION = "0.1.4"
+  VERSION = "0.1.5"
 end

--- a/lib/address_validate/version.rb
+++ b/lib/address_validate/version.rb
@@ -1,3 +1,3 @@
 module AddressValidate
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end

--- a/lib/address_validate/version.rb
+++ b/lib/address_validate/version.rb
@@ -1,3 +1,3 @@
 module AddressValidate
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end

--- a/lib/address_validate/version.rb
+++ b/lib/address_validate/version.rb
@@ -1,3 +1,3 @@
 module AddressValidate
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end


### PR DESCRIPTION
Update endpoints to avoid deprecation warnings and email alerts.